### PR TITLE
Correção de Bug: Validação de 'undefined' no método 'executarCodigo'

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -83,11 +83,9 @@ const executarCodigo = async function () {
     const analisadorSemantico = delegua.analisadorSemantico.analisar(retornoAvaliadorSintatico.declaracoes);
     const erros = analisadorSemantico.erros;
 
-    if(!erros.length) {
-        await delegua.executar({ retornoLexador, retornoAvaliadorSintatico });
-    }
+    if (erros?.length) return mapearErros(erros);
 
-    mapearErros(analisadorSemantico.erros);
+    await delegua.executar({ retornoLexador, retornoAvaliadorSintatico });
 };
 
 botaoTraduzir.addEventListener("click", function () {


### PR DESCRIPTION
### Descrição:
Identifiquei um bug na versão publicada do projeto delegua-web, especificamente no método executarCodigo. O problema ocorre quando a variável errors é undefined, mas ainda assim seu atributo length é acessado (na linha 86). Este acesso resulta em uma exceção, interrompendo a execução esperada do método.

### Evidência:

https://github.com/DesignLiquido/delegua-web/assets/69821028/669e79d3-31fa-4bbb-84d7-a582b5f65aa6

### Correção aplicada:

https://github.com/DesignLiquido/delegua-web/assets/69821028/eabf0bec-b4e3-4696-ac4a-3020cfb1856f