### PR TITLE
Corrigir responsivo do editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,12 +48,15 @@
             <option>Python</option>
             <option>AssemblyScript</option>
         </select>
-      <button id="botaoTraduzir" style="padding-right: 16px;" title="Traduzir">
-        <i class="fa fa-language" style="font-size:20px;"></i>
-      </button>
-      <button id="botaoExecutar" title="Executar">
-        <i class="fa fa-play" style="font-size:20px;"></i>
-      </button>
+        <div>
+            <button id="botaoTraduzir" title="Traduzir">
+							<i class="fa fa-language" style="font-size:20px;"></i>
+            </button>
+
+            <button id="botaoExecutar" title="Executar">
+							<i class="fa fa-play" style="font-size:20px;"></i>
+            </button>
+          </div>
     </div>
   </nav>
 

--- a/scss/estilos.scss
+++ b/scss/estilos.scss
@@ -25,6 +25,11 @@ nav {
         display: flex;
         width: 300px;
         justify-content: space-around;
+
+        div{
+            display: flex;
+            gap: 80px;
+        }
     }
 
     .icone-burger {
@@ -119,6 +124,28 @@ textarea {
     box-shadow: none;
 
     resize: none;
+}
+
+@media only screen and (max-width: 562px) {
+    nav {
+        justify-content: space-around;
+        font-size: 14px;
+        flex-wrap: wrap;
+    }
+
+    .navbar-direita{
+        margin-left: auto;
+
+        #linguagem{
+            order: 2;
+            width: 151px;
+        }
+
+        div{
+            order: 1;
+            gap: 64px;
+        }
+    }
 }
 
 @media only screen and (max-width: 768px) {


### PR DESCRIPTION
Nesta PR corrigo o erro das quebras dos botões em telas menores, abaixo alguns screenshots de como fica em telas maiores  e menores (tablets e smartphones)

## Screenshots

### Smartphones e tablets
![Screenshot (168)](https://github.com/DesignLiquido/delegua-web/assets/69801513/5e7c2c16-5c62-488d-b33c-af6eadc34975)

### Pcs
![Screenshot (169)](https://github.com/DesignLiquido/delegua-web/assets/69801513/9561f63a-c3ba-40f5-b339-66977b335418)
