### PR TITLE
Atualização do método todos

### DIFF
--- a/primitivas/metodos-biblioteca-global.ts
+++ b/primitivas/metodos-biblioteca-global.ts
@@ -293,15 +293,16 @@ export const metodosBibliotecaGlobal: MetodosBibliotecaGlobal = [
     },
     {
         nome: 'todos',
-        documentacao: '### Descrição\n\n' +
-            'Verifica se todos os elementos do vetor satisfazem a condição fornecida pela função de teste.' +
+           documentacao: '### Descrição\n\n' +
+            'Verifica se todos os elementos do vetor são verdadeiros.' +
             '\n\n### Exemplo de Código\n' +
             '```delegua\n' +
-            'var numeros = [2, 4, 6, 8, 10];\n' +
-            'funcao ehPar(valor) { retorna valor % 2 == 0; }\n' +
-            'escreva(todos(numeros, ehPar)); // verdadeiro\n' +
+            'numeros = [1, 2, 3, 4, 5]\n' +
+            'escreva(todos(numeros)) // verdadeiro\n' +
+            'vetorFalso = [1, falso,]\n' +
+            'escreva(todos(vetorFalso)) // falso\n' +
             '```',
-        exemploCodigo: 'todos(vetor, funcaoTeste)'
+        exemploCodigo: 'todos(vetor)'
     },
     {
         nome: 'todosEmCondicao',

--- a/primitivas/metodos-biblioteca-global.ts
+++ b/primitivas/metodos-biblioteca-global.ts
@@ -292,19 +292,6 @@ export const metodosBibliotecaGlobal: MetodosBibliotecaGlobal = [
         exemploCodigo: 'texto(valor)'
     },
     {
-        nome: 'todos',
-           documentacao: '### Descrição\n\n' +
-            'Verifica se todos os elementos do vetor são de valoração verdadeira.' +
-            '\n\n### Exemplo de Código\n' +
-            '```delegua\n' +
-            'numeros = [1, 2, 3, 4, 5]\n' +
-            'escreva(todos(numeros)) // verdadeiro\n' +
-            'vetorFalso = [1, falso,]\n' +
-            'escreva(todos(vetorFalso)) // falso\n' +
-            '```',
-        exemploCodigo: 'todos(vetor)'
-    },
-    {
         nome: 'todosEmCondicao',
         documentacao: '### Descrição\n\n' +
             'Retorna verdadeiro se todos os elementos do vetor retornam verdadeiro ao serem aplicados como argumentos da função passada como segundo parâmetro. Retorna falso em caso contrário.' +

--- a/primitivas/metodos-biblioteca-global.ts
+++ b/primitivas/metodos-biblioteca-global.ts
@@ -294,7 +294,7 @@ export const metodosBibliotecaGlobal: MetodosBibliotecaGlobal = [
     {
         nome: 'todos',
            documentacao: '### Descrição\n\n' +
-            'Verifica se todos os elementos do vetor são verdadeiros.' +
+            'Verifica se todos os elementos do vetor são de valoração verdadeira.' +
             '\n\n### Exemplo de Código\n' +
             '```delegua\n' +
             'numeros = [1, 2, 3, 4, 5]\n' +


### PR DESCRIPTION
Esta PR atualiza a documentação do método `todos` para refletir melhor o comportamento da função, evitando confusões sobre seu funcionamento. Agora, a descrição destaca que a função `todos` retorna verdadeiro apenas quando todos os elementos do iterável são verdadeiros, e falso caso contrário. Enquanto a descrição anterior sugeria que a função retornava verdadeiro se todos os elementos atendessem à condição, o que não é o caso, já que a função `todosEmCondicao` é a responsável por esse comportamento específico.