### PR TITLE
Corrigindo erro na geração "se senaose senao"

### DIFF
--- a/snippets/delegua-code-snippets.ts
+++ b/snippets/delegua-code-snippets.ts
@@ -61,7 +61,7 @@ const deleguaCodeSnippets = [
 		prefixo: "se senaose senao",
 		corpo: [
 			"se (${1:condicao1}) {",
-			"\t$escreva('correspondente 1');",
+			"\tescreva('correspondente 1');",
 			"} senao se (${2:condicao2}) {",
 			"\tescreva('correspondente 2');",
 			"} senao {",


### PR DESCRIPTION
"se senaose senao"

gera

```
se (condicao1) {
    ('correspondente 1');
} senao se (condicao2) {
    escreva('correspondente 2');
} senao {
    escreva('sem valor correspondente');
}
```

mas deveria gerar

```
se (condicao1) {
    escreva('correspondente 1');
} senao se (condicao2) {
    escreva('correspondente 2');
} senao {
    escreva('sem valor correspondente');
}

```


