### PR TITLE
feat: adicionar sugestões de autocomplete para símbolos declarados

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -1134,11 +1134,17 @@ const configurarLinguagemDelegua = function () {
             }
 
             // Extrair variáveis definidas no código (como módulos importados)
-            const regexVariaveis = /(?:var|variavel|variável|const|constante|fixo)\s+(\w+)\s*=/g;
+            const regexVariaveis = /(?:var|variavel|variável|const|constante|fixo)\s+(\w+)/g;
             const variaveisEncontradas = new Set<string>();
             let match;
 
             while ((match = regexVariaveis.exec(textoCompleto)) !== null) {
+                variaveisEncontradas.add(match[1]);
+            }
+
+            // Extrair variáveis de laço: para (var i = ...) ou para (var item de lista)
+            const regexLaco = /\bpara\s*\(\s*(?:var|variavel|variável)?\s*(\w+)\s*(?:=|de)\b/g;
+            while ((match = regexLaco.exec(textoCompleto)) !== null) {
                 variaveisEncontradas.add(match[1]);
             }
 
@@ -1153,6 +1159,82 @@ const configurarLinguagemDelegua = function () {
                     sortText: `0${nomeVar}` // Priorizar na lista
                 };
             });
+
+            // Extrair funções declaradas: funcao nomeFuncao(params)
+            const regexFuncoes = /\bfuncao\s+(\w+)\s*\(([^)]*)\)/g;
+            const funcoesEncontradas = new Map<string, string[]>();
+            while ((match = regexFuncoes.exec(textoCompleto)) !== null) {
+                const nomeFuncao = match[1];
+                const params = match[2]
+                    .split(',')
+                    .map((p: string) => p.trim())
+                    .filter((p: string) => p.length > 0);
+                funcoesEncontradas.set(nomeFuncao, params);
+            }
+
+            // Extrair funções anônimas atribuídas: var nome = funcao(params)
+            const regexFuncaoAnonima = /(?:var|variavel|variável|const|constante|fixo)\s+(\w+)\s*=\s*funcao\s*\(([^)]*)\)/g;
+            while ((match = regexFuncaoAnonima.exec(textoCompleto)) !== null) {
+                const nomeFuncao = match[1];
+                const params = match[2]
+                    .split(',')
+                    .map((p: string) => p.trim())
+                    .filter((p: string) => p.length > 0);
+                funcoesEncontradas.set(nomeFuncao, params);
+                variaveisEncontradas.delete(nomeFuncao); // evitar duplicata como variável
+            }
+
+            const sugestoesFuncoes = Array.from(funcoesEncontradas.entries()).map(([nomeFuncao, params]) => {
+                const argsSnippet = params.map((p, i) => `\${${i + 1}:${p}}`).join(', ');
+                return {
+                    label: nomeFuncao,
+                    kind: 2, // Function
+                    insertText: params.length > 0 ? `${nomeFuncao}(${argsSnippet})` : `${nomeFuncao}()`,
+                    insertTextRules: 4, // InsertAsSnippet
+                    documentation: `Função ${nomeFuncao}(${params.join(', ')})`,
+                    detail: `(${params.join(', ')})`,
+                    sortText: `0${nomeFuncao}`
+                };
+            });
+
+            // Extrair parâmetros da função atual (função que contém o cursor)
+            const linhasCodigo = textoCompleto.split('\n');
+            const linhaAtual = position.lineNumber - 1;
+            const sugestoesParametros: any[] = [];
+            for (let i = linhaAtual; i >= 0; i--) {
+                const matchFuncaoLocal = linhasCodigo[i].match(/\bfuncao\s+\w*\s*\(([^)]*)\)/);
+                if (matchFuncaoLocal) {
+                    matchFuncaoLocal[1]
+                        .split(',')
+                        .map((p: string) => p.trim().split(':')[0].trim())
+                        .filter((p: string) => p.length > 0)
+                        .forEach((param: string) => {
+                            sugestoesParametros.push({
+                                label: param,
+                                kind: 5, // Field (parâmetro)
+                                insertText: param,
+                                documentation: `Parâmetro ${param}`,
+                                sortText: `0${param}`
+                            });
+                        });
+                    break;
+                }
+            }
+
+            // Extrair nomes de classes declaradas
+            const regexClasse = /\bclasse\s+(?:abstrata?\s+)?([A-ZÂÁÊÉÍÓÔÕÚ]\w*)/g;
+            const classesEncontradas = new Set<string>();
+            while ((match = regexClasse.exec(textoCompleto)) !== null) {
+                classesEncontradas.add(match[1]);
+            }
+
+            const sugestoesClasses = Array.from(classesEncontradas).map(nomeClasse => ({
+                label: nomeClasse,
+                kind: 7, // Class
+                insertText: nomeClasse,
+                documentation: `Classe ${nomeClasse}`,
+                sortText: `0${nomeClasse}`
+            }));
 
             // Sugestões padrão (primitivas e snippets)
             const formatoPrimitivas = primitivas
@@ -1181,7 +1263,7 @@ const configurarLinguagemDelegua = function () {
                     })
                 : [];
 
-            const sugestoes = [...sugestoesVariaveis, ...formatoPrimitivas, ...formatoSnippets].filter(s => s.insertText);
+            const sugestoes = [...sugestoesParametros, ...sugestoesFuncoes, ...sugestoesClasses, ...sugestoesVariaveis, ...formatoPrimitivas, ...formatoSnippets].filter(s => s.insertText);
             return { suggestions: sugestoes };
         }
     });


### PR DESCRIPTION
## Resumo

- Extrai funções declaradas (`funcao nome(params)`) e oferece snippet com os parâmetros
- Extrai funções anônimas atribuídas a variáveis, evitando duplicata na lista de variáveis
- Sugere parâmetros da função onde o cursor está posicionado
- Extrai nomes de classes declaradas como sugestões
- Captura variáveis de laço `para (var i = ...)` e `para (var item de lista)`
- Corrige regex de variáveis para incluir declarações sem valor atribuído (ex: `var x`)

## Plano de testes

- [ ] Declarar uma variável sem valor (`var x`) e verificar se aparece no autocomplete
- [ ] Declarar uma função (`funcao somar(a, b)`) e verificar se aparece com snippet dos parâmetros
- [ ] Posicionar o cursor dentro de uma função e verificar se os parâmetros aparecem como sugestões
- [ ] Declarar uma classe e verificar se o nome aparece nas sugestões
- [ ] Usar laço `para` e verificar se a variável do laço aparece no autocomplete

## Motivação
Durante aulas e demonstrações ao vivo, a ausência de autocomplete para símbolos já declarados tornava a experiência confusa — era necessário lembrar e digitar manualmente o nome exato de cada variável, função ou classe. Esta melhoria torna o editor mais próximo do comportamento do VSCode, facilitando o ensino e a escrita de código.

