### PR TITLE
fix: Correcção do modo dark para toda a interface

### DIFF
--- a/editor.ts
+++ b/editor.ts
@@ -909,6 +909,7 @@ const configurarLinguagemDelegua = function () {
         colors: {}
     });
     Monaco.editor.setTheme('delegua-escuro');
+    document.body.setAttribute('data-tema', 'escuro');
 
     Monaco.languages.registerSignatureHelpProvider('delegua', {
         signatureHelpTriggerCharacters: ['(', ','],
@@ -1445,4 +1446,6 @@ botaoExecutar.addEventListener("click", function () {
 const definirTema = (tema: string) => {
     const temaCustomizado = tema === 'vs-dark' ? 'delegua-escuro' : tema === 'vs' ? 'delegua-claro' : tema;
     Monaco.editor.setTheme(temaCustomizado);
+    const temaEscuro = tema === 'vs-dark' || tema === 'hc-black';
+    document.body.setAttribute('data-tema', temaEscuro ? 'escuro' : 'claro');
 }

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
     </div>
     <select onchange="definirTema(this.value)" id="temaEditor">
       <option value="vs">Padrão</option>
-      <option value="vs-dark">Visual Studio Escuro</option>
+      <option value="vs-dark" selected>Visual Studio Escuro</option>
       <option value="hc-black">Escuro</option>
       <option value="hc-light">Claro</option>
     </select>

--- a/scss/estilos.scss
+++ b/scss/estilos.scss
@@ -236,6 +236,58 @@ textarea {
     height: 55%;
 }
 
+body[data-tema="escuro"] {
+    background-color: #1e1e1e;
+    color: #d4d4d4;
+
+    nav {
+        border-bottom-color: #3c3c3c;
+
+        .icone-burger {
+            background-color: #d4d4d4;
+        }
+    }
+
+    select {
+        background-color: #3c3c3c;
+        color: #d4d4d4;
+        border-color: #3c3c3c;
+    }
+
+    #botaoTraduzir,
+    #botaoCompartilhar,
+    #botaoExecutar {
+        color: #d4d4d4;
+    }
+
+    #editor {
+        border-color: #3c3c3c;
+    }
+
+    #resultadoEditor {
+        background-color: #1e1e1e;
+        color: #d4d4d4;
+        border-color: #3c3c3c;
+    }
+
+    .sidenav {
+        background-color: #252526;
+
+        a {
+            color: #cccccc;
+        }
+
+        a:hover {
+            color: #ffffff;
+        }
+    }
+
+    .exemplos {
+        border-color: #3c3c3c;
+        color: #d4d4d4;
+    }
+}
+
 .toast-notificacao {
     position: fixed;
     top: 20px;


### PR DESCRIPTION
## Resumo

- Ao activar um tema escuro, apenas o editor Monaco adaptava as cores — a barra de navegação, o painel de resultados, o sidenav e o fundo da página mantinham cores claras
- A função `definirTema` passou a aplicar um atributo `data-tema` no `body`, permitindo que o CSS estilize toda a interface de forma reactiva
- O selector de tema no HTML foi sincronizado com o tema inicial do editor (`vs-dark`)

## Ficheiros alterados

**`editor.ts`**
- Na inicialização, aplica `data-tema="escuro"` ao `body`
- `definirTema` actualiza o atributo `data-tema` conforme o tema seleccionado

**`index.html`**
- `<option value="vs-dark">` recebe `selected`, sincronizando o selector com o tema inicial

**`scss/estilos.scss`**
- Adicionado bloco `body[data-tema="escuro"]` com estilos para nav, selects, botões, `#resultadoEditor`, `.sidenav` e `.exemplos`

## Antes / Depois

| Elemento | Antes | Depois |
|---|---|---|
| Barra de navegação | Fundo branco, texto preto | Fundo `#1e1e1e`, texto `#d4d4d4` |
| Painel de resultados | Fundo branco | Fundo `#1e1e1e`, texto `#d4d4d4` |
| Sidenav | Fundo branco | Fundo `#252526`, links `#cccccc` |
| Selector de tema | Mostrava "Padrão" ao carregar | Mostra "Visual Studio Escuro" |

## Screenshots
### O que foi feito
<img width="1854" height="928" alt="image" src="https://github.com/user-attachments/assets/2c323283-d1c5-4e94-aa66-5656ffa1bd01" />


### O que está
<img width="1857" height="1011" alt="image" src="https://github.com/user-attachments/assets/02ef996d-891a-4ad7-b0e1-f95eb0754a8d" />
